### PR TITLE
Update No-IP URL

### DIFF
--- a/lib/no-ip.js
+++ b/lib/no-ip.js
@@ -55,7 +55,7 @@ NoIP.prototype.setIp = function (ip) {
 NoIP.prototype.update = function (ip) {
   var self = this
   this.setIp(ip)
-  axios.get('https://dynupdate.no-ip.com/nic/update', this.options)
+  axios.get('https://dynupdate.noip.com/nic/update', this.options)
     .then(function (response) {
       debug('Got response:', response.status, response.data)
       var data = response.data.trim()


### PR DESCRIPTION
The SSL certificate for https://dynupdate.no-ip.com is invalid.
It looks like the service now uses `noip.com` as a TLD, which has a valid SSL certificate.